### PR TITLE
Remove docker --log-driver=syslog parameter

### DIFF
--- a/programs/doc2pdf
+++ b/programs/doc2pdf
@@ -6,6 +6,6 @@ TOOLBIN=$(dirname $0)
 INPUT=$1
 OUTPUT=$2
 contname=conv.p$$.r$RANDOM.u$UID
-docker run --runtime=runsc --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --log-driver=syslog -i -e docconv_suffix=doc --name $contname libreconv < $INPUT
+docker run --runtime=runsc --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL -i -e docconv_suffix=doc --name $contname libreconv < $INPUT
 docker cp $contname:/home/docconv/out/document.pdf $OUTPUT
 docker rm $contname

--- a/programs/docx2pdf
+++ b/programs/docx2pdf
@@ -6,5 +6,5 @@ TOOLBIN=$(dirname $0)
 INPUT=$1
 OUTPUT=$2
 docker run --rm --runtime=runsc --network=none --ipc=private --memory 1g \
-   --kernel-memory=100M --cap-drop=ALL --log-driver=syslog -i -e docconv_suffix=docx \
+   --kernel-memory=100M --cap-drop=ALL -i -e docconv_suffix=docx \
    libreconv < $INPUT | tar --to-stdout -xf - out/document.pdf > $OUTPUT

--- a/programs/jpeg2jpeg
+++ b/programs/jpeg2jpeg
@@ -2,5 +2,5 @@
 
 INPUT=$1
 OUTPUT=$2
-docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --cap-add SYS_PTRACE --log-driver=syslog -i --rm laundry-programs \
+docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --cap-add SYS_PTRACE -i --rm laundry-programs \
        /bin/bash -c 'cat > /home/docconv/input.jpg && /opt/laundry/bin/convert /home/docconv/input.jpg /home/docconv/output.ppm > conv.out && /opt/laundry/bin/convert -quality 97 /home/docconv/output.ppm /home/docconv/output.jpg >> conv.out && cat /home/docconv/output.jpg' < $INPUT > $OUTPUT

--- a/programs/pdf2pdfa
+++ b/programs/pdf2pdfa
@@ -3,5 +3,5 @@
 INPUT=$1
 OUTPUT=$2
 
-docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --log-driver=syslog -i --rm laundry-programs \
+docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL -i --rm laundry-programs \
        /bin/bash -c 'cat > /home/docconv/input.pdf; /opt/laundry/bin/gs -dPDFA -dBATCH -dNOPAUSE -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -sPDFACompatibilityPolicy=1 -sOutputFile="/home/docconv/output-pdfa.pdf" "/home/docconv/input.pdf" > conv.out; cat /home/docconv/output-pdfa.pdf' < $INPUT > $OUTPUT

--- a/programs/png2png
+++ b/programs/png2png
@@ -2,5 +2,5 @@
 
 INPUT=$1
 OUTPUT=$2
-docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --cap-add SYS_PTRACE --log-driver=syslog -i --rm laundry-programs \
+docker run --runtime=${LAUNDRY_DOCKER_RUNTIME:-runsc} --network=none --ipc=private --memory 1g --kernel-memory=100M --cap-drop=ALL --cap-add SYS_PTRACE -i --rm laundry-programs \
        /bin/bash -c 'cat > /home/docconv/input.png && /opt/laundry/bin/convert /home/docconv/input.png /home/docconv/output.ppm > conv.out && /opt/laundry/bin/convert /home/docconv/output.ppm /home/docconv/output.png >> conv.out && cat /home/docconv/output.png' < $INPUT > $OUTPUT


### PR DESCRIPTION
OSX does not have syslog by default, so this allows running the scripts
on OSX as well. Moreover, docker log driver only logs STDERR/STDOUT, and
those are already handled by the scripts under programs.