### PR TITLE
Dockerfile fixes (cache busting & pkg upgrades)

### DIFF
--- a/docker-build/Dockerfile.libreoffice
+++ b/docker-build/Dockerfile.libreoffice
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
-RUN useradd -m docconv && apt-get update && apt-get -y upgrade && apt-get -y install libreoffice-writer libreoffice-calc
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
+    libreoffice-writer \
+    libreoffice-calc \
+ && rm -rf /var/lib/apt/lists/*
+RUN useradd -m docconv
 USER docconv
 WORKDIR /home/docconv
 ENTRYPOINT set -u && cat > /home/docconv/document.$docconv_suffix && \

--- a/docker-build/Dockerfile.programs-runtime
+++ b/docker-build/Dockerfile.programs-runtime
@@ -5,8 +5,10 @@
 # docker build -f Dockerfile.programs-runtime -t laundry-programs  .
 
 FROM ubuntu:18.04
-RUN apt update
-RUN apt -y install ghostscript imagemagick
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
+    ghostscript \
+    imagemagick \
+ && rm -rf /var/lib/apt/lists/*
 RUN useradd -m docconv
 WORKDIR /home/docconv
 USER docconv


### PR DESCRIPTION
- RUN `apt-get update && apt-get -y install foo` to install latest package of foo
- Clean up apt cache with `rm -rf /var/lib/apt/lists*`
- Upgrade all packages to make sure built image includes latest (security) updates

See: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ and https://pythonspeed.com/articles/security-updates-in-docker/ for further rationale