### PR TITLE
Fix image uploads in swagger-ui

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,11 @@
        [com.taoensso/timbre "4.10.0"]
        [enlive "1.1.6"]
        [hiccup "1.0.5"]
-       [metosin/compojure-api "1.1.13"]
+       ; ring-swagger-ui upgraded manually due to compojure-api 
+       ; having issue https://github.com/swagger-api/swagger-ui/issues/2547
+       ; which breaks image uploads from swagger-ui
+       [metosin/compojure-api "1.1.13" :exclusion [metosin/ring-swagger-ui]]
+       [metosin/ring-swagger-ui "4.5.0"]
        [org.clojure/clojure "1.10.1"]
        [org.clojure/tools.cli "0.4.2"]
        [prismatic/schema "1.1.12"]

--- a/src/laundry/image.clj
+++ b/src/laundry/image.clj
@@ -59,6 +59,6 @@
        :middleware [wrap-multipart-params]
        (let [tempfile (:tempfile file)
              filename (:filename file)]
-         (info "PNG converter received " filename "(" (:size file) "b)")
+         (info "JPEG converter received " filename "(" (:size file) "b)")
          (.deleteOnExit tempfile) ;; cleanup if VM is terminated
          (api-jpeg2jpeg env tempfile))))))


### PR DESCRIPTION
- `compojure-api` includes `swagger-ui` that crashes on image endpoints. The new version works fine.
- Fixed logging from jpeg conversions talking about png's.

See https://github.com/swagger-api/swagger-ui/issues/2547 for discussion about the `swagger-ui` bug and https://github.com/metosin/compojure-api/pull/439 for the stale pull request in `compojure-api`