### PR TITLE
`/antivirus/scan` introduced with ClamAV

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,9 @@ Vagrant brings up an Centos Stream 8 VM with all the required dependencies. The 
 Connect to the VM with `vagrant ssh` and do `cd /vagrant`:
  
 - Run `./docker-build/build-all.sh` to (re)build the required Docker images. 
-- Run `./vagrant-dev/compile.sh` to compile the HTTP API with leiningen
-- Run `./vagrant-dev/devserver.sh` to start the HTTP API at `http://192.168.123.123:8080/`
+- Run `./vagrant-dev/compile.sh` to compile the HTTP API with leiningen.
+- Run `docker run --name laundry-clamav -d --rm clamav/clamav:latest` to start the ClamAV container on the background.
+- Run `./vagrant-dev/devserver.sh` to start the HTTP API at `http://192.168.123.123:8080/`.
 
 To work with Clojure REPL from the host you should first run `lein repl :start` inside the VM and then connect to it from the host with `lein repl :connect`.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git clone https://github.com/solita/laundry.git
 ./laundry/docker-demo/build-and-run.sh
 ```
 
-The script builds the necessary docker images including a temporary `laundry-demo`. It starts a docker containers for the `laundry` HTTP server and for the ClamAV. The Docker host socket is exposed to the container, so that the `laundry-demo` can create temporary sibling containers for each conversion. `gVisor runsc` runtime is **not used** in the demo installation.
+The script builds the necessary docker images including a temporary `laundry-demo`. It starts docker containers for the `laundry` HTTP server and for the ClamAV. The Docker host socket is exposed to the container, so that the `laundry-demo` can create temporary sibling containers for each conversion. `gVisor runsc` runtime is **not used** in the demo installation.
 
 Default port is `8080`. The port can be given as parameter to the script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,17 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "laundry-dev"
   config.vm.box = "centos/stream8"
 
+  # ClamAV needs quite a lot of memory, thus providing 8 GiB 
+  config.vm.provider "libvirt" do |v|
+    v.memory = 8192
+    v.cpus = 2
+  end
+  # ... also with virtualbox for those who use it
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 8192
+    v.cpus = 2
+  end
+
   # Excluded '.git' from rsync-auto to reduce unnecessary syncs
   # Excluded 'target' from rsync-auto to not lose compiled jars from the VM on each sync
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ['.git/', 'target/']

--- a/docker-demo/Dockerfile.laundry-demo
+++ b/docker-demo/Dockerfile.laundry-demo
@@ -6,9 +6,12 @@ RUN apk update && \
   curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/local/bin/lein && \
   chmod +x /usr/local/bin/lein
 
-WORKDIR /
-RUN git clone https://github.com/solita/laundry.git
+RUN mkdir /laundry
 WORKDIR /laundry
+COPY programs/ programs/
+COPY resources/ resources/
+COPY src/ src/
+COPY project.clj .
 RUN echo "${API_KEY}" > api-key && \
   lein uberjar
 

--- a/docker-demo/build-and-run.sh
+++ b/docker-demo/build-and-run.sh
@@ -25,8 +25,11 @@ DIR="$( dirname -- "$( readlink -f -- "$0"; )"; )"
 
 api_key="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 32)"
 
+echo Running ClamAV container...
+docker run --name laundry-clamav -d --rm clamav/clamav:latest
+
 echo Building laundry...
-docker build -t laundry-demo "$DIR" --build-arg PORT="$port" --build-arg API_KEY="$api_key" --file "$DIR"/Dockerfile.laundry-demo
+docker build -t laundry-demo "$DIR"/.. --build-arg PORT="$port" --build-arg API_KEY="$api_key" --file "$DIR"/Dockerfile.laundry-demo
 
 echo Running laundry...
 id="$(docker run --name laundry-demo -d --rm -p "$port:$port" -v /var/run/docker.sock:/var/run/docker.sock --group-add "$(cut -d: -f3 < <(getent group docker))" -e LAUNDRY_DOCKER_RUNTIME=runc laundry-demo)"
@@ -47,5 +50,5 @@ echo
 echo "Using api key: $api_key"
 echo "Demo server available at http://$ip:$port"
 echo
-echo "To stop and destroy the container please run: docker stop laundry-demo"
+echo "To stop and destroy the containers please run: docker stop laundry-demo && docker stop laundry-clamav"
 echo

--- a/programs/antivirus
+++ b/programs/antivirus
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -u
+
+INPUT=$1
+
+# Return codes:
+#  0 : No virus found.
+#  1 : Virus(es) found OR failed to connect to the docker container.
+#  2 : An error occured while clamdscan was running.
+docker exec \
+  -i \
+  laundry-clamav clamdscan - \
+  < "$INPUT" 

--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,7 @@
        :init (println "Now (go)")
        :timeout 900000 ; 90s, needed for slow machines
        :port 43210 ; Vagrantfile opens this port for host access
+       :host "0.0.0.0" ; allow connections from outside the vm
        }
    :main laundry.main
    :test-selectors {:default (complement :integration)

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -24,6 +24,26 @@ a:hover { color: #098809; text-decoration: underline }
     converter(form, seln)
   }
 
+  function antivirusScanner() {
+    var form = document.getElementById("scanop");
+    var formData = new FormData(form);
+    var xhr = new XMLHttpRequest();
+    if (form[0].files.length != 1) {
+      alert("Select a file first");
+      return;
+    }
+    xhr.open("POST", "antivirus/scan", true);
+    xhr.onload = function() {
+      if (xhr.status == 200) {
+        alert("Good, no viruses found.")
+      }
+      else {
+        alert("Bad!\n" + xhr.response)
+      }
+    }
+    xhr.send(formData);
+  }
+
   function converter(form, seln) {
     var formData = new FormData(form);
     var xhr = new XMLHttpRequest();
@@ -87,5 +107,12 @@ a:hover { color: #098809; text-decoration: underline }
      <input type="button" value="Convert" onclick="documentConverter()">
    </form>
 
+   <hr>
+
+   <p>Antivirus</p>
+   <form id="scanop">
+    <input type="file" name="file">
+    <input type="button" value="Scan" onclick="antivirusScanner()">
+   </form>
 </body>
 </html>

--- a/src/laundry/antivirus.clj
+++ b/src/laundry/antivirus.clj
@@ -1,0 +1,39 @@
+(ns laundry.antivirus
+  (:require
+   [clojure.string :as string]
+   [compojure.api.sweet :as sweet :refer [POST]]
+   [laundry.machines :as machines]
+   [laundry.util :refer [shell-without-out!]]
+   [ring.middleware.multipart-params :refer [wrap-multipart-params]]
+   [ring.swagger.upload :as upload]
+   [ring.util.http-response :as htresp]
+   [schema.core :as s]
+   [taoensso.timbre :as timbre :refer [info warn]]))
+
+(s/defn api-clamdscan [env, tempfile :- java.io.File]
+  (let [path (.getAbsolutePath tempfile)
+        res (shell-without-out! (str (:tools env) "/antivirus") path)]
+    (.delete tempfile)
+    ;; The following cases are pretty complex as we need to prepare
+    ;; for errors from docker in addition to clamdscan exit codes
+    (case (:exit res)
+      0 (htresp/content-type (htresp/ok) "text/plain")
+      1 (if (string/includes? (:out res) "Infected files: 1")
+          (do
+            (warn (str "Viruses found! " (:out res)))
+            (htresp/content-type (htresp/bad-request (str "Viruses found! " (:out res))) "text/plain")) 
+          (machines/badness-resp "Failed to start antivirus scan!" res))
+      (machines/badness-resp "Error while performing antivirus scan!" res))))
+
+(machines/add-api-generator!
+ (fn [env]
+   (sweet/context "/antivirus" []
+     (POST "/scan" []
+       :summary "scan attached file for viruses"
+       :multipart-params [file :- upload/TempFileUpload]
+       :middleware [wrap-multipart-params]
+       (let [tempfile (:tempfile file)
+             filename (:filename file)]
+         (info "Antivirus scanner received " filename "(" (:size file) "b)")
+         (.deleteOnExit tempfile) ;; cleanup if VM is terminated
+         (api-clamdscan env tempfile))))))

--- a/src/laundry/antivirus.clj
+++ b/src/laundry/antivirus.clj
@@ -3,7 +3,7 @@
    [clojure.string :as string]
    [compojure.api.sweet :as sweet :refer [POST]]
    [laundry.machines :as machines]
-   [laundry.util :refer [shell-without-out!]]
+   [laundry.util :refer [shell-out!]]
    [ring.middleware.multipart-params :refer [wrap-multipart-params]]
    [ring.swagger.upload :as upload]
    [ring.util.http-response :as htresp]
@@ -12,18 +12,18 @@
 
 (s/defn api-clamdscan [env, tempfile :- java.io.File]
   (let [path (.getAbsolutePath tempfile)
-        res (shell-without-out! (str (:tools env) "/antivirus") path)]
+        res (shell-out! (str (:tools env) "/antivirus") path)]
     (.delete tempfile)
     ;; The following cases are pretty complex as we need to prepare
     ;; for errors from docker in addition to clamdscan exit codes
-    (case (:exit res)
-      0 (htresp/content-type (htresp/ok) "text/plain")
-      1 (if (string/includes? (:out res) "Infected files: 1")
-          (do
-            (warn (str "Viruses found! " (:out res)))
-            (htresp/content-type (htresp/bad-request (str "Viruses found! " (:out res))) "text/plain")) 
-          (machines/badness-resp "Failed to start antivirus scan!" res))
-      (machines/badness-resp "Error while performing antivirus scan!" res))))
+    (cond
+      (and (string/blank? (:err res)) (= (:exit res) 0) (string/includes? (:out res) "Infected files: 0"))
+      (htresp/content-type (htresp/ok) "text/plain") ;; no viruses
+      (and (string/blank? (:err res)) (= (:exit res) 1) (string/includes? (:out res) "Infected files: 1"))
+      (do
+        (warn (str "Viruses found! " (:out res)))
+        (htresp/content-type (htresp/bad-request (str "Viruses found! " (:out res))) "text/plain"))
+      :else (machines/badness-resp "Error while performing antivirus scan!" res))))
 
 (machines/add-api-generator!
  (fn [env]

--- a/src/laundry/machines.clj
+++ b/src/laundry/machines.clj
@@ -28,9 +28,3 @@
   (warn (str msg ": " log))
   (htresp/content-type (htresp/internal-server-error (str msg))
                        "text/plain"))
-
-(defn not-there-resp [msg]
-  (htresp/content-type (htresp/internal-server-error (str msg))
-                       "text/plain"))
-
-(def ok htresp/ok)

--- a/src/laundry/server.clj
+++ b/src/laundry/server.clj
@@ -1,12 +1,12 @@
 (ns laundry.server
   (:require
-   [clojure.java.io :as io]
    [clojure.string :as string]
    [compojure.api.sweet :as sweet :refer [api undocumented GET context routes]]
    [compojure.route]
 
    ;; Require the machine defining namespaces
    [laundry.machines :as machines]
+   laundry.antivirus
    laundry.docx
    laundry.xlsx
    laundry.image
@@ -24,13 +24,6 @@
 
 (defn timestamp []
   (.getTime (java.util.Date.)))
-
-(s/defn temp-file-input-stream [path :- s/Str]
-  (let [input (io/input-stream (io/file path))]
-    (proxy [java.io.FilterInputStream] [input]
-      (close []
-        (proxy-super close)
-        (io/delete-file path)))))
 
 (defn create-auth-middleware [env]
   (let [configured-password ((or (get env :basic-auth-password) (constantly nil)))]

--- a/src/laundry/util.clj
+++ b/src/laundry/util.clj
@@ -3,6 +3,13 @@
    [clojure.java.shell :as shell]
    [taoensso.timbre :as timbre :refer [warn]]))
 
+(defn shell-without-out! [binary-path input-path]
+  (try
+    (shell/sh binary-path input-path)
+    (catch java.io.IOException ex ;; sometimes throws instead of returning error, contrary to docs
+      (warn ex "java.shell/sh threw exception, translating as exit value 10000")
+      {:out "" :err "" :exit 10000 :exception ex})))
+
 (defn shell-out! [binary-path input-path output-path]
   (try
     (shell/sh binary-path input-path output-path)

--- a/src/laundry/util.clj
+++ b/src/laundry/util.clj
@@ -3,16 +3,9 @@
    [clojure.java.shell :as shell]
    [taoensso.timbre :as timbre :refer [warn]]))
 
-(defn shell-without-out! [binary-path input-path]
+(defn shell-out! [& args]
   (try
-    (shell/sh binary-path input-path)
-    (catch java.io.IOException ex ;; sometimes throws instead of returning error, contrary to docs
-      (warn ex "java.shell/sh threw exception, translating as exit value 10000")
-      {:out "" :err "" :exit 10000 :exception ex})))
-
-(defn shell-out! [binary-path input-path output-path]
-  (try
-    (shell/sh binary-path input-path output-path)
+    (apply shell/sh args)
     (catch java.io.IOException ex ;; sometimes throws instead of returning error, contrary to docs
       (warn ex "java.shell/sh threw exception, translating as exit value 10000")
       {:out "" :err "" :exit 10000 :exception ex})))

--- a/test/laundry/antivirus_missing_container_test.clj
+++ b/test/laundry/antivirus_missing_container_test.clj
@@ -1,0 +1,19 @@
+(ns laundry.antivirus-missing-container-test
+  (:require
+   [clojure.test :refer [deftest is use-fixtures]]
+   [laundry.test.fixture :as fixture]
+   [peridot.multipart]
+   [ring.mock.request :as mock]
+   [ring.util.request]))
+
+(use-fixtures :once fixture/batch-peridot-build-with-string-fixture!)
+
+(deftest ^:integration api-clamdscan-without-container-running
+  (let [app (fixture/get-app)
+        request (-> (mock/request :post "/antivirus/scan")
+                    (merge (peridot.multipart/build {:file fixture/eicar-antivirus-test-file-contents})))
+        response (app request)
+        body (ring.util.request/body-string response)]
+    (is (= 500 (:status response)))
+    (is (= body "Error while performing antivirus scan!"))))
+

--- a/test/laundry/antivirus_test.clj
+++ b/test/laundry/antivirus_test.clj
@@ -1,0 +1,36 @@
+(ns laundry.antivirus-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string  :as string]
+   [clojure.test :refer [deftest is use-fixtures]]
+   [laundry.test.fixture :as fixture]
+   [peridot.multipart]
+   [ring.mock.request :as mock]
+   [ring.util.request]))
+
+(defn laundry-clamav-fixture! [f]
+  (shell/sh "docker" "run" "--name" "laundry-clamav" "--env" "CLAMAV_NO_FRESHCLAMD=true" "--network=none" "--rm" "-d" "clamav/clamav:latest")
+  ;; clamd bootup is somewhat slow, thus need to sleep a bit before container can be used
+  (Thread/sleep 30000)
+  (f)
+  (shell/sh "docker" "stop" "laundry-clamav"))
+
+(use-fixtures :once laundry-clamav-fixture! fixture/batch-peridot-build-with-string-fixture!)
+
+(deftest ^:integration api-clamdscan-no-virus
+  (let [app (fixture/get-app)
+        file (io/file (io/resource "hypno.pdf"))
+        request (-> (mock/request :post "/antivirus/scan")
+                    (merge (peridot.multipart/build {:file file})))
+        response (app request)]
+    (is (= 200 (:status response)))))
+
+(deftest ^:integration api-clamdscan-virus-detected
+  (let [app (fixture/get-app)
+        request (-> (mock/request :post "/antivirus/scan")
+                    (merge (peridot.multipart/build {:file fixture/eicar-antivirus-test-file-contents})))
+        response (app request)
+        body (ring.util.request/body-string response)]
+    (is (= 400 (:status response)))
+    (is (string/starts-with? body "Viruses found!"))))

--- a/test/laundry/antivirus_unhealthy_container_test.clj
+++ b/test/laundry/antivirus_unhealthy_container_test.clj
@@ -1,0 +1,25 @@
+(ns laundry.antivirus-unhealthy-container-test
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.test :refer [deftest is use-fixtures]]
+   [laundry.test.fixture :as fixture]
+   [peridot.multipart]
+   [ring.mock.request :as mock]
+   [ring.util.request]))
+
+(defn laundry-unhealthy-clamav-fixture! [f]
+  ;; start clamav container without clamd to make the scans fail on error
+  (shell/sh "docker" "run" "--name" "laundry-clamav" "--env" "CLAMAV_NO_FRESHCLAMD=true" "--env" "CLAMAV_NO_CLAMD=true" "--network=none" "--rm" "-d" "clamav/clamav:latest")
+  (f)
+  (shell/sh "docker" "stop" "laundry-clamav"))
+
+(use-fixtures :once laundry-unhealthy-clamav-fixture! fixture/batch-peridot-build-with-string-fixture!)
+
+(deftest ^:integration api-clamdscan-unhealthy-container
+  (let [app (fixture/get-app)
+        request (-> (mock/request :post "/antivirus/scan")
+                    (merge (peridot.multipart/build {:file fixture/eicar-antivirus-test-file-contents})))
+        response (app request)
+        body (ring.util.request/body-string response)]
+    (is (= 500 (:status response)))
+    (is (= body "Error while performing antivirus scan!"))))

--- a/test/laundry/test/fixture.clj
+++ b/test/laundry/test/fixture.clj
@@ -1,7 +1,11 @@
 (ns laundry.test.fixture
   (:require
    [laundry.machines :as machines]
-   [laundry.server :as server]))
+   [laundry.server :as server]
+   [peridot.multipart])
+  (:import
+   (org.apache.http.entity.mime MultipartEntity)
+   (org.apache.http.entity.mime.content ByteArrayBody)))
 
 (def test-conf
   {:tools "programs"})
@@ -13,3 +17,14 @@
 
 (defn get-app []
   (get-app-with test-conf))
+
+;; fixture for invoking peridot.multipart/build with strings converted to files
+(defn batch-peridot-build-with-string-fixture! [f]
+  (defmethod peridot.multipart/add-part String [^MultipartEntity m k ^String s]
+    (.addPart m
+              (peridot.multipart/ensure-string k)
+              (ByteArrayBody. (.getBytes s) "text/plain" "foobar.txt")))
+  (f)
+  (remove-method peridot.multipart/add-part String))
+
+(def eicar-antivirus-test-file-contents "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*")


### PR DESCRIPTION
Here is a proposal about integration with ClamAV for anti-virus scans. 

An HTTP endpoint at `/antivirus/scan` tells whether the provided file had any viruses etc:
- The response status is 200 when there were no viruses detected and scan succeeded
- The response status is 400 when viruses were detected. The scan output is included as plain text in response body.
- The response status is 500 when scan failed to be executed (could happen due to docker container being unavailable, ClamAV being broken, etc).

I'll push a bit more info to the swagger-ui documentation soon... and add some tests too.

These are my first ever lines of Clojure, thus expect bugs & typos :) 