### PR TITLE
Fix release asset name in GitHub workflow

### DIFF
--- a/.github/workflows/release-from-tags.yml
+++ b/.github/workflows/release-from-tags.yml
@@ -36,6 +36,6 @@ jobs:
           draft: true
           files: |
             release-${{ GITHUB.REF_NAME }}.tar.gz
-            docker-image-laundry-programs.tar.gz
+            docker-image-laundry-programs-${{ GITHUB.REF_NAME }}.tar.gz
           fail_on_unmatched_files: true
           generate_release_notes: true


### PR DESCRIPTION
A small typo caused release workflow failures. Now the name matches the one created in line 28.