### PR TITLE
pdf2pdfa: write the file to be converted into the container before co…

### DIFF
--- a/programs/pdf2pdfa
+++ b/programs/pdf2pdfa
@@ -14,5 +14,6 @@ docker run \
   -i \
   --rm \
   laundry-programs \
-  /bin/bash -c 'gs -q -dPDFA -dBATCH -dNOPAUSE -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- -' \
-  < "$INPUT" > "$OUTPUT"
+    /bin/bash -c 'cat > /home/docconv/document.pdf && \
+    gs -q -dPDFA -dBATCH -dNOPAUSE -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
+    < "$INPUT" > "$OUTPUT"


### PR DESCRIPTION
…nversion.

The docs for gs say that a temporary file is created if a PDF file is passed from stdin (https://ghostscript.com/docs/9.54.0/Use.htm#PDF_stdin)

Running the container with debug enabled (https://gvisor.dev/docs/user_guide/debugging/),
the strace log is filled by around 99% with read system calls:
```
I0425 10:44:28.208667  2309340 strace.go:567] [   1:   1] gs E read(0x0 host:[1], 0x56032b5174b1, 0x1)
I0425 10:44:28.208675  2309340 strace.go:605] [   1:   1] gs X read(0x0 host:[1], 0x56032b5174b1 "P", 0x1) = 1 (0x1) (1.932µs)
```

This (according to ChatGPT) means that one byte at a time is read from stdin.
ChatGPT: "It looks like you have provided a log output from a program using strace to trace system calls on a Linux system. The log shows a read system call being made by a program called "gs" with process ID 1. The read call is reading 1 byte of data from file descriptor 0 (which is typically standard input) and storing it at memory address 0x56032b5174b1.

The log also shows that the read call returned successfully with a return value of 1, indicating that one byte of data was successfully read. The call took 1.932 microseconds to complete. "

I believe these read system calls are part of how 'gs' creates the temporary pdf file. This doesn't seem very efficient. 'cat' reads in bigger batches. i.e with less system calls.

pdf2pdfa conversion took ~6 minutes for a ~10MB file and ~30 seconds for a ~1MB file.
After this change conversion takes ~15s and ~2s respectively. (On a VM, ptrace platform for gVisor)
