### PR TITLE
Pdf/a conversion performance parameters

### DIFF
--- a/programs/pdf2pdfa
+++ b/programs/pdf2pdfa
@@ -4,6 +4,15 @@ set -u
 
 INPUT=$1
 OUTPUT=$2
+DPI=$3
+if [ -z "$DPI" ]; then
+  DPI=720
+fi
+re='^[0-9]+$'
+if ! [[ $DPI =~ $re ]] ; then
+  echo "error: DPI is not a number"
+  exit 2
+fi
 
 docker run \
   --runtime="${LAUNDRY_DOCKER_RUNTIME:-runsc}" \
@@ -15,5 +24,5 @@ docker run \
   --rm \
   laundry-programs \
     /bin/bash -c 'cat > /home/docconv/document.pdf && \
-    gs -q -dPDFA -dBATCH -dNOPAUSE -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
+    gs -q -dPDFA -dBATCH -dNOPAUSE -r'$DPI' -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
     < "$INPUT" > "$OUTPUT"

--- a/programs/pdf2pdfa
+++ b/programs/pdf2pdfa
@@ -5,12 +5,22 @@ set -u
 INPUT=$1
 OUTPUT=$2
 DPI=$3
+MAXBITMAP=$4
+
 if [ -z "$DPI" ]; then
   DPI=720
 fi
 re='^[0-9]+$'
 if ! [[ $DPI =~ $re ]] ; then
   echo "error: DPI is not a number"
+  exit 2
+fi
+
+if [ -z "$MAXBITMAP" ]; then
+  MAXBITMAP=0
+fi
+if ! [[ $MAXBITMAP =~ $re ]] ; then
+  echo "error: MAXBITMAP is not a number"
   exit 2
 fi
 
@@ -24,5 +34,5 @@ docker run \
   --rm \
   laundry-programs \
     /bin/bash -c 'cat > /home/docconv/document.pdf && \
-    gs -q -dPDFA -dBATCH -dNOPAUSE -r'$DPI' -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
+    gs -q -dPDFA -dBATCH -dNOPAUSE -r'$DPI' -dMaxBitmap='$MAXBITMAP' -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
     < "$INPUT" > "$OUTPUT"

--- a/programs/pdf2pdfa
+++ b/programs/pdf2pdfa
@@ -6,6 +6,7 @@ INPUT=$1
 OUTPUT=$2
 DPI=$3
 MAXBITMAP=$4
+PDFSETTINGS=$5
 
 if [ -z "$DPI" ]; then
   DPI=720
@@ -14,6 +15,24 @@ re='^[0-9]+$'
 if ! [[ $DPI =~ $re ]] ; then
   echo "error: DPI is not a number"
   exit 2
+fi
+
+
+if [ -n "$PDFSETTINGS" ]; then
+  valid_settings=("/screen" "/ebook" "/printer" "/prepress" "/default")
+  for i in "${valid_settings[@]}"
+  do
+    if [ "$i" = "$PDFSETTINGS" ] ; then
+      found=true
+    fi
+  done
+  if [ "$found" != true ]; then
+    echo "error: Invalid PDFSETTINGS value"
+    exit 2
+  fi
+  PDFSETTINGS="-dPDFSETTINGS=$PDFSETTINGS"
+else
+  PDFSETTINGS="-dPDFSETTINGS=/default"
 fi
 
 if [ -z "$MAXBITMAP" ]; then
@@ -34,5 +53,5 @@ docker run \
   --rm \
   laundry-programs \
     /bin/bash -c 'cat > /home/docconv/document.pdf && \
-    gs -q -dPDFA -dBATCH -dNOPAUSE -r'$DPI' -dMaxBitmap='$MAXBITMAP' -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
+    gs -q -dPDFA -dBATCH -dNOPAUSE -r'$DPI' -dMaxBitmap='$MAXBITMAP' '$PDFSETTINGS' -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=1 -sOutputFile=- /home/docconv/document.pdf' \
     < "$INPUT" > "$OUTPUT"

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -6,10 +6,23 @@ a { color: #098809; text-decoration: none }
 a:hover { color: #098809; text-decoration: underline }
 </style>
 <script>
+  var pdfParameters = [
+    {"type": "pdf/pdf2pdfa", key: "dpi", wrapper: "pdf_dpi_elem", elem: "pdf_dpi" }
+  ]
+
+  function updateConversionParameters() {
+    var seln = document.getElementById("pdfOperation");
+    for (const param of pdfParameters) {
+      document.getElementById(param.wrapper).hidden = (param.type !== seln.value);
+    }
+  }
+
   function pdfConverter() {
     var form = document.getElementById("pdfop");
     var seln = document.getElementById("pdfOperation");
-    converter(form, seln)
+    var args = pdfParameters.filter(item => item.type == seln.value)
+      .map(arg => ({key: arg.key, value: parseInt(document.getElementById(arg.elem).value).toString()}));
+    converter(form, seln, args)
   }
 
   function imageConverter() {
@@ -44,14 +57,15 @@ a:hover { color: #098809; text-decoration: underline }
     xhr.send(formData);
   }
 
-  function converter(form, seln) {
+  function converter(form, seln, args) {
     var formData = new FormData(form);
     var xhr = new XMLHttpRequest();
     if (form[0].files.length != 1) {
       alert("Select a file first");
       return;
     }
-    xhr.open("POST", seln.value, true);
+    var argsString = args && args.length ? "?" + args.map(function(arg) { return arg.key + "=" + encodeURIComponent(arg.value) }).join("&") : ""
+    xhr.open("POST", seln.value + argsString, true);
     xhr.responseType = "blob";
     xhr.onload = function(e) {
       var urlsource= window.URL || window.webkitURL;
@@ -63,19 +77,22 @@ a:hover { color: #098809; text-decoration: underline }
 </script>
 <title>Laundry</title>
 </head>
-<body>
+<body onload="updateConversionParameters()">
    <h1>Laundry</h1>
    <a href="api-docs">Swagger API</a>
 
    <hr>
 
    <p>PDF
-     <select id="pdfOperation">
+     <select id="pdfOperation" onchange="updateConversionParameters()">
        <option value="pdf/pdf-preview">preview</option>
        <option value="pdf/pdf2pdfa">to PDF/A</option>
        <option value="pdf/pdf2txt">to text
      </select>
    </p>
+   <div id="pdf_dpi_elem">
+     <input type="number" id="pdf_dpi" name="dpi" value="720"> DPI
+   </div>
    <form id="pdfop">
    <input type="file" name="file">
    <input type="button" value="Convert" onclick="pdfConverter()">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -7,7 +7,8 @@ a:hover { color: #098809; text-decoration: underline }
 </style>
 <script>
   var pdfParameters = [
-    {"type": "pdf/pdf2pdfa", key: "dpi", wrapper: "pdf_dpi_elem", elem: "pdf_dpi" }
+    {"type": "pdf/pdf2pdfa", key: "dpi", wrapper: "pdf_dpi_elem", elem: "pdf_dpi" },
+    {"type": "pdf/pdf2pdfa", key: "maxbitmap", wrapper: "pdf_maxbitmap_elem", elem: "pdf_maxbitmap" }
   ]
 
   function updateConversionParameters() {
@@ -92,6 +93,9 @@ a:hover { color: #098809; text-decoration: underline }
    </p>
    <div id="pdf_dpi_elem">
      <input type="number" id="pdf_dpi" name="dpi" value="720"> DPI
+   </div>
+   <div id="pdf_maxbitmap_elem">
+     <input type="number" id="pdf_maxbitmap" name="maxbitmap" value="0"> Maxbitmap
    </div>
    <form id="pdfop">
    <input type="file" name="file">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -7,8 +7,9 @@ a:hover { color: #098809; text-decoration: underline }
 </style>
 <script>
   var pdfParameters = [
-    {"type": "pdf/pdf2pdfa", key: "dpi", wrapper: "pdf_dpi_elem", elem: "pdf_dpi" },
-    {"type": "pdf/pdf2pdfa", key: "maxbitmap", wrapper: "pdf_maxbitmap_elem", elem: "pdf_maxbitmap" }
+    {"type": "pdf/pdf2pdfa", key: "dpi", dtype: "number", wrapper: "pdf_dpi_elem", elem: "pdf_dpi" },
+    {"type": "pdf/pdf2pdfa", key: "maxbitmap", dtype: "number", wrapper: "pdf_maxbitmap_elem", elem: "pdf_maxbitmap" },
+    {"type": "pdf/pdf2pdfa", key: "pdfsettings", wrapper: "pdf_pdfsettings_elem", elem: "pdf_pdfsettings" }
   ]
 
   function updateConversionParameters() {
@@ -22,7 +23,10 @@ a:hover { color: #098809; text-decoration: underline }
     var form = document.getElementById("pdfop");
     var seln = document.getElementById("pdfOperation");
     var args = pdfParameters.filter(item => item.type == seln.value)
-      .map(arg => ({key: arg.key, value: parseInt(document.getElementById(arg.elem).value).toString()}));
+      .map(arg => ({
+        key: arg.key,
+        value: arg.dtype === "number" ? parseInt(document.getElementById(arg.elem).value).toString() : document.getElementById(arg.elem).value
+      }));
     converter(form, seln, args)
   }
 
@@ -96,6 +100,9 @@ a:hover { color: #098809; text-decoration: underline }
    </div>
    <div id="pdf_maxbitmap_elem">
      <input type="number" id="pdf_maxbitmap" name="maxbitmap" value="0"> Maxbitmap
+   </div>
+   <div id="pdf_pdfsettings_elem">
+     <input type="text" id="pdf_pdfsettings" name="pdfsettings" value="/default"> Pdfsettings
    </div>
    <form id="pdfop">
    <input type="file" name="file">

--- a/test/laundry/pdf_test.clj
+++ b/test/laundry/pdf_test.clj
@@ -39,6 +39,20 @@
     (is (= "application/pdf" (get-in response [:headers "Content-Type"])))
     (is (clojure.string/starts-with? body "%PDF-"))))
 
+(deftest ^:integration api-pdf-pdf2pdfa-with-opt-args
+  (let [app (fixture/get-app)
+        file (io/file (io/resource "hypno.pdf"))
+        _ (assert file)
+        request (-> (mock/request :post "/pdf/pdf2pdfa")
+                    (assoc-in [:query-params :dpi] 720)
+                    (assoc-in [:query-params :maxbitmap] 0)
+                    (merge (peridot.multipart/build {:file file})))
+        response (app request)
+        body (ring.util.request/body-string response)]
+    (is (= 200 (:status response)))
+    (is (= "application/pdf" (get-in response [:headers "Content-Type"])))
+    (is (clojure.string/starts-with? body "%PDF-"))))
+
 (deftest ^:integration api-pdf-pdf2txt
   (let [app (fixture/get-app)
         file (io/file (io/resource "hypno.pdf"))

--- a/test/laundry/pdf_test.clj
+++ b/test/laundry/pdf_test.clj
@@ -46,6 +46,7 @@
         request (-> (mock/request :post "/pdf/pdf2pdfa")
                     (assoc-in [:query-params :dpi] 720)
                     (assoc-in [:query-params :maxbitmap] 0)
+                    (assoc-in [:query-params :pdfsettings] "/default")
                     (merge (peridot.multipart/build {:file file})))
         response (app request)
         body (ring.util.request/body-string response)]


### PR DESCRIPTION
This adds new performance parameters for pdf/a conversion which have an effect on the underlying ghostscript command performance. The existing API can be called without specifying these new parameters, so the values specified as defaults for these parameters are used.