### PR TITLE
Docx to pdfa conversion

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -9,7 +9,7 @@ jobs:
         run: |
           set -e
           ARCH=$(uname -m)
-          URL=https://storage.googleapis.com/gvisor/releases/release/20230130/${ARCH}
+          URL=https://storage.googleapis.com/gvisor/releases/release/20241210/${ARCH}
           sudo wget ${URL}/runsc ${URL}/runsc.sha512 \
             ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
           sha512sum -c runsc.sha512 \

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Install the prerequisites:
  
 **Note:** We recommend running [Docker Bench for Security](https://github.com/docker/docker-bench-security) before proceeding with the installation. It checks your Docker installation for common security-related best practices.
 
+Note that the Ubuntu 24.04 LTS -image is tested with gVisor version 20241210. Previously used version in tests was 20230130, which did not work with the newest Ubuntu LTS.
+
 Download [a release](https://github.com/solita/laundry/releases) and lets and install laundry as systemd service. The following example assumes that:
 
 - Current user is `laundry`

--- a/docker-build/Dockerfile.laundry-programs
+++ b/docker-build/Dockerfile.laundry-programs
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     ghostscript \
     imagemagick \

--- a/programs/docx2pdf
+++ b/programs/docx2pdf
@@ -4,6 +4,7 @@ set -u
 
 INPUT=$1
 OUTPUT=$2
+PDFVERSION=$3
 
 docker run \
   --runtime="${LAUNDRY_DOCKER_RUNTIME:-runsc}" \
@@ -18,7 +19,7 @@ docker run \
     mkdir -p /home/docconv/out &&  umask 077 &&      \
     soffice                                          \
     --headless                                       \
-    --convert-to pdf:writer_pdf_Export               \
+    --convert-to pdf:writer_pdf_Export:"{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":'\"$PDFVERSION\"'}}" \
     --outdir /home/docconv/out                       \
     /home/docconv/document.docx > conv.out 2>&1;     \
     tar -cf - conv.out out/*; ls -la . out >> conv.out' \

--- a/src/laundry/docx.clj
+++ b/src/laundry/docx.clj
@@ -10,11 +10,24 @@
    [schema.core :as s]
    [taoensso.timbre :as timbre :refer [info]]))
 
-(s/defn api-docx2pdf [env, tempfile :- java.io.File]
+(s/defschema PdfVersion
+  "Check for allowed PDF versions as specified in LibreOffice documentation here: https://help.libreoffice.org/latest/en-US/text/shared/guide/pdf_params.html
+   Listing allowed choices as of 11.12.2024, LibreOffice version 24.8
+   0: PDF 1.7 (default choice).
+   1: PDF/A-1b
+   2: PDF/A-2b
+   3: PDF/A-3b
+   15: PDF 1.5
+   16: PDF 1.6
+   17: PDF 1.7"
+  (s/constrained s/Int (fn [version-number]
+                       (contains? #{0 1 2 3 15 16 17} version-number))))
+
+(s/defn api-docx2pdf [env, tempfile :- java.io.File pdf-version :- PdfVersion]
   (let [in-path (.getAbsolutePath tempfile)
         out-path  (str in-path ".pdf")
         res (shell-out! (str (:tools env) "/docx2pdf")
-                        in-path out-path)]
+                        in-path out-path (str pdf-version))]
     (.delete tempfile) ;; todo: move to finally block
     (if (= (:exit res) 0)
       (htresp/content-type
@@ -27,10 +40,11 @@
    (sweet/context "/docx" []
      (POST "/docx2pdf" []
        :summary "attempt to convert a .docx file to PDF"
+       :query-params #_{:clj-kondo/ignore [:unresolved-symbol]} [{pdf-version :- PdfVersion 0}]
        :multipart-params [file :- upload/TempFileUpload]
        :middleware [wrap-multipart-params]
        (let [tempfile (:tempfile file)
              filename (:filename file)]
-         (info "docx converter received " filename "(" (:size file) "b)")
+         (info "docx converter received " filename "(" (:size file) "b), requested pdf-version: " pdf-version)
          (.deleteOnExit tempfile) ;; cleanup if VM is terminated
-         (api-docx2pdf env tempfile))))))
+         (api-docx2pdf env tempfile pdf-version))))))

--- a/test/laundry/docx_test.clj
+++ b/test/laundry/docx_test.clj
@@ -16,4 +16,4 @@
         response (app request)
         body (ring.util.request/body-string response)]
     (is (= 200 (:status response)))
-    (is (clojure.string/starts-with? body "%PDF-1.4"))))
+    (is (clojure.string/starts-with? body "%PDF-1."))))

--- a/test/laundry/xlsx_test.clj
+++ b/test/laundry/xlsx_test.clj
@@ -16,4 +16,4 @@
         response (app request)
         body (ring.util.request/body-string response)]
     (is (= 200 (:status response)))
-    (is (clojure.string/starts-with? body "%PDF-1.4"))))
+    (is (clojure.string/starts-with? body "%PDF-1."))))


### PR DESCRIPTION
Update to a newer Ubuntu LTS version to gain access to a newer version of LibreOffice, which has cli configuration for PDF conversions. Fix tests due to new LibreOffice producing newer pdf versions by default.

Implement pdfversion parameter to docx2pdf API's, which defaults to 0. This equates to not having set the pdf version at all, retaining previous functionality.